### PR TITLE
Optimize VRAM usage during training

### DIFF
--- a/train.py
+++ b/train.py
@@ -50,7 +50,7 @@ def requires_grad(model, flag=True):
     for p in model.parameters():
         p.requires_grad = flag
 
-
+@torch.no_grad()
 def accumulate(model1, model2, decay=0.999):
     par1 = dict(model1.named_parameters())
     par2 = dict(model2.named_parameters())
@@ -293,9 +293,11 @@ def train(conf, loader, generator, discriminator, g_optim, d_optim, g_ema, devic
                 )
 
             if i % 100 == 0:
+                generator.zero_grad()
+                discriminator.zero_grad()
                 with torch.no_grad():
                     g_ema.eval()
-                    sample = g_ema(sample_z)
+                    sample = g_ema(sample_z).cpu()
                     utils.save_image(
                         sample,
                         f"sample/{str(i).zfill(6)}.png",
@@ -303,6 +305,7 @@ def train(conf, loader, generator, discriminator, g_optim, d_optim, g_ema, devic
                         normalize=True,
                         value_range=(-1, 1),
                     )
+                    sample = None # cleanup memory
 
             if i % 10000 == 0:
                 torch.save(


### PR DESCRIPTION
This PR reduces the VRAM usage of the training loop: fixes #16 
* Allows 4X increase in batchsize with same number of samples on a 1080TI. Instead of taking up 4X the amount of memory as all the other GPUs, now it only takes up an additional 200mb.
* It moves the inference images to CPU as soon as possible which tells PyTorch immediately frees the underlying GPU memory.
* It also zeros the gradient of the previous backprop so that the memory of those gradients don't have to co-exist with the second forward pass used for inference.
* It ensures the gradients of the generator aren't accidentally stored in the accumulated ema weights (they shouldn't be in the current codebase but this is just an extra sanity check / documentation of desired behavior).
Overall, this allows me to fix a batch size of 4 on a 1080TI, where as before I could only fit a batch size of 1. This all works with the default number of samples (16).
 